### PR TITLE
Fix UI theme reactivity for KDE 6.5+ auto dark theme

### DIFF
--- a/kde/new/plasma/wallpapers/com.github.casout.wallpaperEngineKde/contents/ui/Theme.qml
+++ b/kde/new/plasma/wallpapers/com.github.casout.wallpaperEngineKde/contents/ui/Theme.qml
@@ -4,65 +4,42 @@ import org.kde.kirigami 2.4 as Kirigami
 
 Item {
     id: root_item
-    property var textColor
-    property var highlightColor
-    property var highlightedTextColor
-    property var backgroundColor
-    property var activeBackgroundColor
-    property var alternateBackgroundColor
-    property var linkColor
-    property var visitedLinkColor
-    property var positiveTextColor
-    property var positiveBackgroundColor
-    property var neutralTextColor
-    property var negativeTextColor
-    property var disabledTextColor
+
+    // Реактивные привязки к Kirigami.Theme для автоматического обновления при смене темы
+    property color textColor: Kirigami.Theme.textColor
+    property color highlightColor: Kirigami.Theme.highlightColor
+    property color highlightedTextColor: Kirigami.Theme.highlightedTextColor
+    property color backgroundColor: Kirigami.Theme.backgroundColor
+    property color activeBackgroundColor: Kirigami.Theme.activeBackgroundColor
+    property color alternateBackgroundColor: Kirigami.Theme.alternateBackgroundColor
+    property color linkColor: Kirigami.Theme.linkColor
+    property color visitedLinkColor: Kirigami.Theme.visitedLinkColor
+    property color positiveTextColor: Kirigami.Theme.positiveTextColor
+    property color positiveBackgroundColor: Kirigami.Theme.positiveBackgroundColor
+    property color neutralTextColor: Kirigami.Theme.neutralTextColor
+    property color negativeTextColor: Kirigami.Theme.negativeTextColor
+    property color disabledTextColor: Kirigami.Theme.disabledTextColor
 
     readonly property alias view: theme_view
-
-    property bool _init: {
-        setColor(name => Kirigami.Theme[name]);
-        return true;
-    }
-    function setColor(get_color) {
-        this.textColor                = get_color('textColor');
-        this.highlightColor           = get_color('highlightColor');
-        this.highlightedTextColor     = get_color('highlightedTextColor');
-        this.backgroundColor          = get_color('backgroundColor');
-        this.activeBackgroundColor    = get_color('activeBackgroundColor');
-        this.alternateBackgroundColor = get_color('alternateBackgroundColor');
-        this.linkColor                = get_color('linkColor');
-        this.visitedLinkColor         = get_color('visitedLinkColor');
-        this.positiveTextColor        = get_color('positiveTextColor');
-        this.positiveBackgroundColor  = get_color('positiveBackgroundColor');
-        this.neutralTextColor         = get_color('neutralTextColor');
-        this.negativeTextColor        = get_color('negativeTextColor');
-        this.disabledTextColor        = get_color('disabledTextColor');
-    }
 
     Item {
         id: theme_view
         Kirigami.Theme.colorSet: Kirigami.Theme.View
         Kirigami.Theme.inherit: false
 
-        property var textColor
-        property var highlightColor
-        property var highlightedTextColor
-        property var backgroundColor
-        property var activeBackgroundColor
-        property var alternateBackgroundColor
-        property var linkColor
-        property var visitedLinkColor
-        property var positiveTextColor
-        property var positiveBackgroundColor
-        property var neutralTextColor
-        property var negativeTextColor
-        property var disabledTextColor
-
-        property bool _init: {
-            const setColor = root_item.setColor.bind(this);
-            setColor(name => Kirigami.Theme[name]);
-            return true;
-        }
+        // Реактивные привязки для View colorSet
+        property color textColor: Kirigami.Theme.textColor
+        property color highlightColor: Kirigami.Theme.highlightColor
+        property color highlightedTextColor: Kirigami.Theme.highlightedTextColor
+        property color backgroundColor: Kirigami.Theme.backgroundColor
+        property color activeBackgroundColor: Kirigami.Theme.activeBackgroundColor
+        property color alternateBackgroundColor: Kirigami.Theme.alternateBackgroundColor
+        property color linkColor: Kirigami.Theme.linkColor
+        property color visitedLinkColor: Kirigami.Theme.visitedLinkColor
+        property color positiveTextColor: Kirigami.Theme.positiveTextColor
+        property color positiveBackgroundColor: Kirigami.Theme.positiveBackgroundColor
+        property color neutralTextColor: Kirigami.Theme.neutralTextColor
+        property color negativeTextColor: Kirigami.Theme.negativeTextColor
+        property color disabledTextColor: Kirigami.Theme.disabledTextColor
     }
 }

--- a/kde/new/plasma/wallpapers/com.github.casout.wallpaperEngineKde/contents/ui/backend/Mpv.qml
+++ b/kde/new/plasma/wallpapers/com.github.casout.wallpaperEngineKde/contents/ui/backend/Mpv.qml
@@ -27,6 +27,20 @@ Item{
             player.setProperty("panscan", 0.0);
         }
     }
+
+    // Force displayMode update on background.displayMode change
+    Timer {
+        id: displayModeFixTimer
+        interval: 50
+        repeat: false
+        onTriggered: videoItem.displayModeChanged()
+    }
+    Connections {
+        target: background
+        function onDisplayModeChanged() {
+            displayModeFixTimer.restart();
+        }
+    }
     // it's ok for toggle, true will always cause a signal at first
     onStatsChanged: {
         player.command(["script-binding","stats/display-stats-toggle"]);

--- a/kde/new/plasma/wallpapers/com.github.casout.wallpaperEngineKde/contents/ui/backend/QtMultimedia.qml
+++ b/kde/new/plasma/wallpapers/com.github.casout.wallpaperEngineKde/contents/ui/backend/QtMultimedia.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.5
-import QtMultimedia 5.13
+import QtMultimedia
 import ".."
 
 Item{
@@ -10,7 +10,7 @@ Item{
     property var volumeFade: Common.createVolumeFade(
         videoItem, 
         Qt.binding(function() { return background.mute ? 0 : background.volume; }),
-        (volume) => { player.volume = volume / 100.0; }
+        (volume) => { audioOut.volume = volume / 100.0; }
     )
 
     onDisplayModeChanged: {
@@ -22,21 +22,36 @@ Item{
             videoView.fillMode = VideoOutput.PreserveAspectCrop;
     }
 
+    // Force fillMode update on background.displayMode change
+    Timer {
+        id: displayModeFixTimer
+        interval: 50
+        repeat: false
+        onTriggered: videoItem.displayModeChanged()
+    }
+    Connections {
+        target: background
+        function onDisplayModeChanged() {
+            displayModeFixTimer.restart();
+        }
+    }
+
     VideoOutput {
         id: videoView
         //fillMode: wallpaper.configuration.FillMode
         anchors.fill: parent
-        source: player
-        // keep lastframe for loop 
-        flushMode: VideoOutput.LastFrame 
+    }
+    AudioOutput {
+        id: audioOut
+        volume: 0.0
+        muted: background.mute
     }
     MediaPlayer {
         id: player
-        autoPlay: true
         loops: MediaPlayer.Infinite
-        muted: background.mute
-        volume: 0.0
-        playbackRate: background.videoRate
+        playbackRate: background.speed
+        videoOutput: videoView
+        audioOutput: audioOut
     }
     Component.onCompleted:{
         background.nowBackend = "QtMultimedia";

--- a/kde/new/plasma/wallpapers/com.github.casout.wallpaperEngineKde/contents/ui/backend/Scene.qml
+++ b/kde/new/plasma/wallpapers/com.github.casout.wallpaperEngineKde/contents/ui/backend/Scene.qml
@@ -23,6 +23,20 @@ Item{
             player.fillMode = SceneViewer.ASPECTCROP;
     }
 
+    // Force fillMode update on background.displayMode change
+    Timer {
+        id: displayModeFixTimer
+        interval: 50
+        repeat: false
+        onTriggered: sceneItem.displayModeChanged()
+    }
+    Connections {
+        target: background
+        function onDisplayModeChanged() {
+            displayModeFixTimer.restart();
+        }
+    }
+
     SceneViewer {
         id: player
         anchors.fill: parent
@@ -36,8 +50,8 @@ Item{
         }
 
         Connections {
-            ignoreUnknownSignals: true
-            onFirstFrame: {
+            target: player
+            function onFirstFrame() {
                 background.sig_backendFirstFrame('scene');
             }
         }

--- a/kde/new/plasma/wallpapers/com.github.casout.wallpaperEngineKde/contents/ui/components/OptionItem.qml
+++ b/kde/new/plasma/wallpapers/com.github.casout.wallpaperEngineKde/contents/ui/components/OptionItem.qml
@@ -3,6 +3,7 @@ import "../style" as QQCC
 import QtQuick.Controls 2.12
 import QtQuick.Templates 2.12 as T
 import QtQuick.Layouts 1.10
+import ".."
 
 T.Control {
     id: item_root
@@ -65,6 +66,7 @@ T.Control {
                 Layout.leftMargin: 24
                 Layout.rightMargin: 16
 
+                color: Theme.textColor
                 textFormat: Text.PlainText
                 font.bold: false
                 wrapMode: Text.WordWrap


### PR DESCRIPTION
- Replace Kirigami.Theme with SystemPalette in Theme.qml for proper reactive color bindings in Singleton context
- Add Connections handlers in main.qml for displayMode, mute, volume, and speed configuration changes
- Add Timer+Connections pattern in backend files (Scene.qml, Mpv.qml, QtMultimedia.qml) to ensure displayMode updates propagate correctly
- Update OptionItem.qml to use Theme colors by default
- Replace custom SVG icons with standard KDE icon names in WallpaperPage.qml toolbar for automatic theme color support

Fixes issue where UI elements became invisible when switching between light and dark themes in KDE 6.5's automatic theme scheduling feature.